### PR TITLE
MG새마을금고, KB국민카드 프로그램 자동 설치 순서 변경

### DIFF
--- a/docs/Catalog.xml
+++ b/docs/Catalog.xml
@@ -170,8 +170,8 @@
 		<Service Id="MGSaemaeul" DisplayName="MG새마을금고" Category="Banking" Url="https://ibs.kfcc.co.kr/">
 			<CompatNotes>MG새마을금고의 경우 해당 기관의 보안 정책에 따라 AhnLab Safe Transaction이 Windows Sandbox의 필수 구성 요소인 RDP 세션을 강제 종료하도록 구성되어있습니다. https://yourtablecloth.app/troubleshoot.html 페이지를 참고하여 AST가 원격 연결을 허용하도록 사이트 이용 전에 먼저 변경한 후 접속하는 것을 권장합니다.</CompatNotes>
 			<Packages>
-				<Package Name="WizInDelfino" Url="https://ibs.kfcc.co.kr/common/wizvera/delfino/down/delfino-g3.exe" Arguments="/silent" />
 				<Package Name="AhnLabSafeTx" Url="https://safetx.ahnlab.com/master/win/default/all/astx_setup.exe" Arguments="/silent" />
+				<Package Name="WizInDelfino" Url="https://ibs.kfcc.co.kr/common/wizvera/delfino/down/delfino-g3.exe" Arguments="/silent" />
 			</Packages>
 		</Service>
 		<Service Id="Shinhyub" DisplayName="신협" Category="Banking" Url="https://openbank.cu.co.kr/">
@@ -980,8 +980,8 @@
 			<CompatNotes>KB국민카드의 경우 해당 기관의 보안 정책에 따라 AhnLab Safe Transaction이 Windows Sandbox의 필수 구성 요소인 RDP 세션을 강제 종료하도록 구성되어있습니다. https://yourtablecloth.app/troubleshoot.html 페이지를 참고하여 AST가 원격 연결을 허용하도록 사이트 이용 전에 먼저 변경한 후 접속하는 것을 권장합니다.</CompatNotes>
 			<Packages>
 				<Package Name="Veraport" Url="https://download.kbcard.com/security/wizvera/veraport-g3/veraport-g3-x64.exe" Arguments="/silent" />
-				<Package Name="WizInDelfino" Url="https://download.kbcard.com/security/wizvera/delfino-g3/delfino-g3.exe" Arguments="/silent" />
 				<Package Name="AhnLabSafeTx" Url="https://safetx.ahnlab.com/master/win/default/all/astx_setup.exe" Arguments="/silent" />
+				<Package Name="WizInDelfino" Url="https://download.kbcard.com/security/wizvera/delfino-g3/delfino-g3.exe" Arguments="/silent" />
 			</Packages>
 		</Service>
 		<Service Id="Hanacard" DisplayName="하나카드" Category="CreditCard" Url="https://www.hanacard.co.kr/">


### PR DESCRIPTION
### 현재 발생하는 문제
Ahnlab Safe Transaction 원격 접속 차단 기능 활용 사이트에서 Ahnlab Safe Transaction 설치가 가장 후 순위인 MG새마을금고와 KB국민카드의 경우 원격 접속 차단 설정을 풀기 전에 사이트가 열려 샌드박스가 닫히는 문제가 있습니다.

### 본 Pull Request의 내용
본 문제의 영향을 받는 MG새마을금고와 KB국민카드의 Ahnlab Safe Transaction 설치 순위를 변경하여 Ahnlab Safe Transaction가 설치된 후 다음 프로그램이 설치되는 시간 동안 원격 접속 차단 설정을 해제할 수 있도록 함으로써 문제를 해결하고자 합니다.