### PR TITLE
:pencil: feat: 모두의 프린터 다운로드 링크 변경

### DIFF
--- a/docs/Catalog.xml
+++ b/docs/Catalog.xml
@@ -7,7 +7,7 @@
 	-->
 	<Companions>
 		<!-- 모두의 프린터 -->
-		<Companion Id="EveryonesPrinter" DisplayName="모두의 프린터" Url="https://blog.kakaocdn.net/dn/BbHiA/btrj2gYTiEo/TeCEgV3VJuemSgjLZWc3T1/PIRODOWN_MOP64.exe?attach=1&amp;knm=tfile.exe" Arguments="" />
+		<Companion Id="EveryonesPrinter" DisplayName="모두의 프린터" Url="https://mop.pirodown.win/ebp325_x64.exe" Arguments="" />
 	</Companions>
 	<InternetServices>
 		<!-- 인터넷 뱅킹 시작 (https://www.kfb.or.kr/member/list_regular.php 참고함) -->


### PR DESCRIPTION
모두의 프린터 개발자님이 티스토리에서 워드프레스로 이사를 가시며, 기존 다운로드 링크가 더 이상 작동하지 않습니다.
따라서 모두의 프린터 개발자님이 새로 공개하신 R2 CDN의 다운로드 링크로 카탈로그를 업데이트합니다.