### PR TITLE
사이트 헬스 체크 워크플로 도구 추가 (checksites.cs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -436,3 +436,4 @@ FodyWeavers.xsd
 # End of https://www.toptal.com/developers/gitignore/api/dotnetcore,visualstudio,visualstudiocode,windows
 
 /outputs/
+/health-report/

--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ dotnet run .\src\fetchfavicon.cs https://www.example.com .\docs\images\Banking\E
 
 특히 파비콘이 없거나 매우 작은 아이콘만 제공하는 사이트의 경우, AI 도구를 활용하면 훨씬 깔끔한 로고 이미지를 얻을 수 있습니다.
 
+#### 사이트 헬스 체크 도구 (checksites.cs)
+
+카탈로그에 등록된 웹 사이트들의 접속 가능성을 Microsoft Edge(Windows x64로 가장)로 점검하고, 사람의 검토를 거쳐 카탈로그를 갱신할 수 있게 도와주는 도구입니다. 식탁보가 실행되는 Edge IE Mode 환경에 맞춰 User-Agent·Client Hints·`navigator.platform`을 Windows Edge로 일치시켜 진단합니다.
+
+```powershell
+# 자동 헬스 체크 (헤드리스, 스크린샷 + report.json/.md 생성)
+dotnet run .\src\checksites.cs probe .\docs\ .\health-report\
+
+# 사람 판정 단계 (라이브 URL을 시스템 브라우저로 띄우고 verdict 입력)
+dotnet run .\src\checksites.cs triage .\health-report\<timestamp>\
+
+# 후속 작업이 필요한 verdict들을 GitHub 이슈로 자동 등록 (gh CLI 필요)
+dotnet run .\src\checksites.cs issue .\health-report\<timestamp>\
+```
+
+자동 검출과 사람 판정의 분리, GitHub 이슈 자동 등록, AI 어시스트(Claude Code 등)를 활용한 후속 카탈로그 갱신 방법은 [docs/SITE_HEALTH_WORKFLOW.md](docs/SITE_HEALTH_WORKFLOW.md)를 참고하세요.
+
 ### 자동 응답 설치 옵션을 찾는 방법
 
 일반적으로 무인 설치 옵션은 설치 프로그램 명령줄 뒤에 `/?`나 `/help`, `/h`, `--help` 등 도움말을 표시하는 것과 관련된 스위치를 대입하여 실행하면 도움말과 함께 자세한 자동 응답 설치 옵션을 사용하는 방법을 표시합니다.

--- a/docs/SITE_HEALTH_WORKFLOW.md
+++ b/docs/SITE_HEALTH_WORKFLOW.md
@@ -1,0 +1,243 @@
+# 사이트 헬스 체크 워크플로
+
+이 문서는 카탈로그에 등록된 웹 사이트들의 접속 가능성을 주기적으로 점검하고, AI 어시스트(Claude Code 등)와 함께 카탈로그를 갱신하는 절차를 설명합니다.
+
+## 전체 흐름
+
+```text
+[1] probe   (자동, 헤드리스)       →   report.json + 스크린샷
+        │
+        ▼
+[2] triage  (대화형, 사람 판정)    →   triage.json (사람 verdict 포함)
+        │
+        ▼
+[3] issue   (gh CLI 자동화)        →   GitHub 이슈 등록 (verdict별 1건씩)
+        │
+        ▼
+[4] AI 어시스트 (Claude Code 등)   →   Catalog.xml / sites.xml 패치 후보
+        │
+        ▼
+[5] 본인 검토 + commit/PR (이슈 닫기)
+        │
+        ▼
+[6] 변경분 재검증 (probe --only)   →   다음 라운드까지 stale 제거
+```
+
+자동화는 **검출(detect)**까지만 — "이 사이트가 정상이다"의 최종 판정은 사람이 합니다. 휴리스틱은 우선순위를 매기는 도구이지 판결문이 아닙니다.
+
+## 1. probe — 자동 헬스 체크
+
+```bash
+dotnet run --file src/checksites.cs -- probe ./docs/ ./health-report/
+```
+
+각 카탈로그 항목에 대해 Microsoft Edge(헤드리스, Windows x64로 가장)로 접속을 시도하고 다음을 캡처합니다. 식탁보가 실제로 동작하는 Edge IE Mode 환경과 일치시키기 위해 User-Agent, Client Hints 헤더(`sec-ch-ua-*`), `navigator.platform`, `navigator.userAgentData`를 모두 Windows Edge 값으로 설정합니다.
+
+- 최종 URL (리다이렉트 후), HTTP status, 페이지 타이틀, 에러
+- 뷰포트 스크린샷 (1280×800)
+
+결과는 `health-report/<UTC-timestamp>/`에 저장됩니다.
+
+```text
+health-report/2026-05-06T010203Z/
+├── report.json          # 머신리더블 결과 (probe 단계)
+├── report.md            # 사람이 읽기 쉬운 요약
+└── screenshots/
+    ├── WooriBank.png
+    └── ...
+```
+
+### 분류 (3-tier)
+
+| Tier | 의미 | 트리거 (strong signals) |
+|------|------|--------|
+| `AutoOk` | 자동으로 정상 추정 | strong signal 없음 |
+| `NeedsReview` | 사람 검토 필요 | 4xx/5xx, 도메인 변경 redirect, 종료 키워드(`서비스 종료`, `통합되었습니다`, `이전되었습니다` 등), timeout/SSL/connection-reset 등 |
+| `AutoDead` | 사망 추정 | DNS 실패, connection refused |
+
+타이틀이 비어있는 것(`empty-title`)은 weak signal로 기록만 되며 단독으론 NeedsReview를 트리거하지 않습니다 — 한국 공공/금융 사이트는 JS 렌더링이 끝난 뒤에 타이틀을 채우는 경우가 많아 false positive가 너무 많기 때문입니다. (probe는 빈 타이틀일 때 1.5초 대기 후 재조회로 자동 보정합니다.)
+
+`AutoOk`도 "사람이 봐도 정상"이 아니라 "자동 검사로 의심점이 없음"입니다. 의심되면 `triage --all`로 전수 검토 가능.
+
+### 자주 쓰는 옵션
+
+```bash
+# 일부만 재검증 (예: 방금 수정한 항목만)
+dotnet run --file src/checksites.cs -- probe ./docs/ ./health-report/ --only WooriBank,KookminBank
+
+# 동시성/타임아웃 조정
+dotnet run --file src/checksites.cs -- probe ./docs/ ./health-report/ --concurrency 8 --timeout-ms 45000
+```
+
+## 2. triage — 대화형 사람 판정
+
+```bash
+dotnet run --file src/checksites.cs -- triage ./health-report/2026-05-06T010203Z/
+```
+
+`NeedsReview` 항목을 한 건씩 보여주며, 자동으로 시스템 브라우저에 라이브 URL을 띄워 직접 클릭 확인할 수 있게 해줍니다. 본인의 쿠키·인증서·확장 프로그램이 그대로 사용되므로 한국 공공/금융 사이트의 인증 흐름까지 검증할 수 있습니다.
+
+각 항목마다 verdict를 입력합니다:
+
+| 키 | 의미 | 추가 입력 |
+|----|------|----------|
+| `o` | healthy — 사이트 정상 | (메모만) |
+| `d` | dead — 사이트 폐쇄 | (메모만) |
+| `c` | url-changed — URL이 바뀜 | 새 URL + 메모 |
+| `m` | merged-or-renamed — 기관 통폐합/명칭변경 | 후속 기관 Id(선택) + 메모 |
+| `u` | unsure — 추가 조사 필요 | (메모) |
+| `s` | skip — 이번엔 건너뜀 | (저장 안 함, 다음 실행 시 재출현) |
+| `q` | quit — 즉시 종료 (지금까지 저장은 보존) | — |
+
+verdict는 입력 즉시 `triage.json`에 저장되어 도중에 끊어도 다음 실행 시 이어서 진행됩니다.
+
+### triage 옵션
+
+```bash
+# AutoOk까지 모두 전수 검토
+dotnet run --file src/checksites.cs -- triage <report-dir> --all
+
+# 시스템 브라우저 자동 오픈 비활성화 (URL만 출력)
+dotnet run --file src/checksites.cs -- triage <report-dir> --no-browser
+```
+
+## 3. issue — GitHub 이슈 자동 등록
+
+triage 결과에서 후속 작업이 필요한 verdict들을 GitHub 이슈로 자동 등록합니다. `gh` CLI가 설치·로그인되어 있어야 합니다.
+
+```bash
+dotnet run --file src/checksites.cs -- issue ./health-report/2026-05-06T010203Z/
+```
+
+이슈가 생성되는 verdict:
+
+- `dead` — 사이트 폐쇄 의심
+- `merged-or-renamed` — 기관 통폐합/명칭변경 의심
+- `unsure` — 추가 조사 필요
+- `url-changed` — **도메인이 변경된 경우만** (같은 도메인 내 URL 변경은 단순 PR로 충분하므로 이슈를 만들지 않습니다)
+
+`healthy`나 verdict가 없는 항목은 이슈가 만들어지지 않습니다.
+
+이슈 본문은 자기완결적입니다 — 카탈로그 항목 메타정보, 사람 verdict + 메모, 권장 조치, ProbedAt/스크린샷 경로 등 후속 처리에 필요한 모든 컨텍스트가 포함되어 PR 작성 시 따로 설명을 짜낼 필요가 없습니다.
+
+이슈 등록 결과(`IssueUrl`)는 `triage.json`의 해당 verdict에 다시 저장되므로, **여러 번 실행해도 같은 항목을 중복 등록하지 않습니다**.
+
+### issue 옵션
+
+```bash
+# 미리보기 (실제 이슈 안 만듦, 본문/타이틀만 출력)
+dotnet run --file src/checksites.cs -- issue <report-dir> --dry-run
+
+# 다른 리포에 등록
+dotnet run --file src/checksites.cs -- issue <report-dir> --repo yourtablecloth/TableClothCatalog
+
+# 라벨 부여 (라벨이 리포에 미리 존재해야 함)
+dotnet run --file src/checksites.cs -- issue <report-dir> --label site-health
+```
+
+## 4. AI 어시스트 — Claude Code와 카탈로그 갱신
+
+issue까지 끝나면 `triage.json`이 사람 verdict + 등록된 이슈 URL을 포함한 자기완결 입력이 됩니다. Claude Code에 다음을 전달하세요.
+
+### 진입 프롬프트 (복사해서 사용)
+
+```text
+triage.json 경로: <여기에 본인 경로 채우기>
+
+이 파일을 읽고 verdict별로 다음 규칙대로 처리해줘.
+
+verdict별 처리 규칙:
+- url-changed:
+  - newUrl과 originalUrl이 같은 등록 가능 도메인(eTLD+1)에 속하면 docs/Catalog.xml(또는 sites.xml)의 해당 항목 Url 속성을 newUrl로 자동 패치.
+  - 도메인이 다르면 자동 적용하지 말고 먼저 보고 → 본인 승인 후 적용.
+- merged-or-renamed:
+  - 기관 조사 결과(공식 발표·뉴스 출처 URL 포함)를 보고 → 처리 방향(URL 교체/항목 삭제/항목 분할/새 항목 추가) 제안 → 본인 승인 후 적용.
+- dead:
+  - 항목 삭제 후보로 보고. 자동 삭제 금지. 삭제 결정 시 commit 메시지에 사유 명시.
+- unsure:
+  - 추가로 확인이 필요한 정보(예: 정확한 후속 도메인, 인수합병 시점)를 정리해 알려줘.
+- healthy / pending(verdict 없음):
+  - 건드리지 않음.
+
+작업 단위로 commit 분리:
+  (1) 단순 URL 갱신 (같은 도메인)
+  (2) 기관 변경/통폐합
+  (3) 삭제
+
+각 항목에 IssueUrl이 있으면 commit/PR 메시지에 `Closes <IssueUrl>` 형식으로 언급해 자동으로 이슈가 닫히게 해줘.
+
+편집 후:
+  1. dotnet run --file src/catalogutil.cs -- ./docs/ ./outputs/ 로 스키마 검증 통과 확인
+  2. 변경된 Service Id 목록을 모아 다음을 실행:
+     dotnet run --file src/checksites.cs -- probe ./docs/ ./health-report/ --only <id1,id2,...>
+  3. 새 report에서 Tier가 NeedsReview/AutoDead로 떨어지지 않는지 확인 후 보고.
+```
+
+### 자동 vs 확인-먼저 경계선
+
+| 작업 | 자동 패치 | 본인 승인 필요 |
+|------|:---:|:---:|
+| `Url=` 한 속성 변경 (같은 도메인) | ✓ | |
+| 도메인이 바뀌는 URL 교체 | | ✓ |
+| `Service` 항목 삭제 | | ✓ |
+| `Service Id` 변경 | | ✓ |
+| 새 항목 추가 / 항목 분할 | | ✓ |
+| `Packages`·`CompatNotes` 등 부속 필드 수정 | | ✓ |
+
+규칙: **diff가 한 줄이고 의미가 보존되는 변경**만 자동, 그 외는 보고 후 결정.
+
+## 5. 대화 위생
+
+- **triage 한 번 = 대화 한 번**이 이상적. 여러 라운드를 한 대화에 끌고 가면 stale verdict가 컨텍스트에 쌓입니다.
+- 시작할 때 triage.json의 절대 경로와 이번 작업 범위(`url-changed만`, `m verdict만 같이 검토` 등)를 한 줄로 명시.
+- 큰 변경은 commit 단위로 끊어서 — 되돌리기 쉬워집니다.
+
+## 6. 재검증 루프
+
+편집을 마친 뒤 변경된 항목만 재-probe해서 상태가 회복되었는지 확인합니다.
+
+```bash
+dotnet run --file src/checksites.cs -- probe ./docs/ ./health-report/ --only WooriBank,KookminBank
+```
+
+새 report의 Tier가 모두 `AutoOk`이면 라운드 종료. 여전히 `NeedsReview`/`AutoDead`로 떨어지면 다시 triage로.
+
+## triage.json 스키마 (참고)
+
+```jsonc
+{
+  "SchemaVersion": 1,
+  "CatalogRoot": "/abs/path/to/docs/",
+  "ProbedAt": "2026-05-06T01:02:03Z",
+  "UpdatedAt": "2026-05-06T01:30:00Z",
+  "Entries": [
+    {
+      "Probe": {
+        "Id": "WooriBank",
+        "DisplayName": "우리은행 개인뱅킹",
+        "Category": "Banking",
+        "Source": "Catalog.xml",
+        "Url": "https://www.wooribank.com/",
+        "FinalUrl": "https://www.wooribank.com/",
+        "HttpStatus": 200,
+        "Title": "우리은행",
+        "Error": null,
+        "ScreenshotPath": "screenshots/WooriBank.png",
+        "Tier": "AutoOk",
+        "Signals": [],
+        "ProbedAt": "2026-05-06T01:02:03Z"
+      },
+      "Verdict": {
+        "Kind": "healthy",        // healthy | dead | url-changed | merged-or-renamed | unsure
+        "NewUrl": null,           // url-changed일 때 채워짐
+        "SuccessorId": null,      // merged-or-renamed일 때 선택적
+        "Notes": null,
+        "VerdictAt": "2026-05-06T01:30:00Z",
+        "IssueUrl": null          // issue 단계 후 채워짐 (멱등성에 사용)
+      }
+    }
+  ]
+}
+```
+
+`Verdict`가 `null`이면 아직 사람 판정이 없는 항목입니다. AI는 verdict가 채워진 항목만 처리해야 합니다.

--- a/src/checksites.cs
+++ b/src/checksites.cs
@@ -1,0 +1,1035 @@
+#!/usr/bin/env dotnet
+#:package Microsoft.Playwright@1.59.0
+#:property PublishAot=false
+
+using Microsoft.Playwright;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+
+Console.OutputEncoding = Encoding.UTF8;
+
+if (args.Length == 0)
+    return PrintUsage();
+
+return args[0].ToLowerInvariant() switch
+{
+    "probe" => await RunProbeAsync(args.Skip(1).ToArray()),
+    "triage" => await RunTriageAsync(args.Skip(1).ToArray()),
+    "issue" => await RunIssueAsync(args.Skip(1).ToArray()),
+    "help" or "-h" or "--help" => PrintUsage(),
+    var unknown => UnknownSubcommand(unknown),
+};
+
+static int PrintUsage()
+{
+    Console.ForegroundColor = ConsoleColor.Cyan;
+    Console.WriteLine("Site Health Checker for TableCloth Catalog");
+    Console.ResetColor();
+    Console.WriteLine();
+    Console.WriteLine("Usage:");
+    Console.WriteLine("  dotnet run --file src/checksites.cs -- probe  <catalog-dir> <output-dir> [options]");
+    Console.WriteLine("  dotnet run --file src/checksites.cs -- triage <report-dir>              [options]");
+    Console.WriteLine("  dotnet run --file src/checksites.cs -- issue  <report-dir>              [options]");
+    Console.WriteLine();
+    Console.WriteLine("probe options:");
+    Console.WriteLine("  --only <id1,id2,...>   Only check these Service Ids");
+    Console.WriteLine("  --concurrency <N>      Max parallel pages (default: 4)");
+    Console.WriteLine("  --timeout-ms <N>       Per-page navigation timeout (default: 30000)");
+    Console.WriteLine();
+    Console.WriteLine("triage options:");
+    Console.WriteLine("  --all                  Walk every entry, not just NeedsReview");
+    Console.WriteLine("  --no-browser           Don't auto-open the live URL in the system browser");
+    Console.WriteLine();
+    Console.WriteLine("issue options:");
+    Console.WriteLine("  --dry-run              Print issue title/body without calling gh");
+    Console.WriteLine("  --repo <owner/name>    Pass through to gh (default: gh's current repo)");
+    Console.WriteLine("  --label <label>        Pass through to gh (e.g. site-health)");
+    Console.WriteLine();
+    Console.WriteLine("Examples:");
+    Console.WriteLine("  dotnet run --file src/checksites.cs -- probe ./docs/ ./health-report/");
+    Console.WriteLine("  dotnet run --file src/checksites.cs -- triage ./health-report/2026-05-05T143000Z/");
+    Console.WriteLine("  dotnet run --file src/checksites.cs -- issue ./health-report/2026-05-05T143000Z/ --dry-run");
+    return 0;
+}
+
+static int UnknownSubcommand(string name)
+{
+    Console.Error.WriteLine($"Unknown subcommand: {name}");
+    Console.Error.WriteLine("Run with --help for usage.");
+    return 2;
+}
+
+static async Task<int> RunProbeAsync(string[] args)
+{
+    if (args.Length < 2)
+    {
+        Console.Error.WriteLine("probe: <catalog-dir> and <output-dir> are required");
+        return 2;
+    }
+
+    var catalogDir = args[0];
+    var outputBase = args[1];
+    var onlyRaw = ParseOption(args, "--only");
+    var only = onlyRaw?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    var concurrency = int.TryParse(ParseOption(args, "--concurrency"), out var c) && c > 0 ? c : 4;
+    var timeoutMs = int.TryParse(ParseOption(args, "--timeout-ms"), out var t) && t > 0 ? t : 30_000;
+
+    if (!Directory.Exists(catalogDir))
+    {
+        Console.Error.WriteLine($"probe: catalog directory not found: {catalogDir}");
+        return 2;
+    }
+
+    Console.WriteLine($"[probe] catalog     : {Path.GetFullPath(catalogDir)}");
+    Console.WriteLine($"[probe] only        : {(only is null ? "(all)" : string.Join(", ", only))}");
+    Console.WriteLine($"[probe] concurrency : {concurrency}");
+    Console.WriteLine($"[probe] timeout     : {timeoutMs}ms");
+
+    var entries = LoadCatalog(catalogDir, only);
+    var fromCatalog = entries.Count(e => e.Source == "Catalog.xml");
+    var fromSites = entries.Count(e => e.Source == "sites.xml");
+    Console.WriteLine($"[probe] entries     : {entries.Count} (Catalog.xml: {fromCatalog}, sites.xml: {fromSites})");
+    Console.WriteLine();
+
+    if (entries.Count == 0)
+    {
+        Console.Error.WriteLine("[probe] no entries to check — exiting");
+        return 1;
+    }
+
+    if (await EnsurePlaywrightAsync() is var installCode and not 0)
+        return installCode;
+
+    var timestamp = DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHHmmssZ");
+    var outputDir = Path.Combine(outputBase, timestamp);
+    var screenshotsDir = Path.Combine(outputDir, "screenshots");
+    Directory.CreateDirectory(screenshotsDir);
+    Console.WriteLine($"[probe] output      : {Path.GetFullPath(outputDir)}");
+    Console.WriteLine();
+
+    using var playwright = await Playwright.CreateAsync();
+    await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+    {
+        Headless = true,
+        Channel = "msedge",
+    });
+
+    var results = new List<ProbeResult>();
+    var consoleLock = new object();
+    var done = 0;
+
+    await Parallel.ForEachAsync(
+        entries,
+        new ParallelOptions { MaxDegreeOfParallelism = concurrency },
+        async (entry, ct) =>
+        {
+            var raw = await ProbeWithRetryAsync(browser, entry, timeoutMs, screenshotsDir);
+            var (tier, signals) = Classify(raw);
+            var result = raw with { Tier = tier, Signals = signals };
+            var seq = Interlocked.Increment(ref done);
+            lock (consoleLock)
+            {
+                results.Add(result);
+                var status = result.Error is not null
+                    ? $"ERR  {result.Error}"
+                    : $"HTTP {result.HttpStatus?.ToString() ?? "???"}";
+                var sig = result.Signals.Length > 0 ? "  [" + string.Join(", ", result.Signals) + "]" : "";
+                WriteTierBadge(result.Tier);
+                Console.WriteLine($" [{seq,3}/{entries.Count}] {result.Id,-40} {status}{sig}");
+            }
+        });
+
+    Console.WriteLine();
+    var byTier = results.GroupBy(r => r.Tier).ToDictionary(g => g.Key, g => g.Count());
+    Console.WriteLine($"[probe] done: {results.Count} entries probed");
+    Console.WriteLine($"[probe] tiers: AutoOk={byTier.GetValueOrDefault("AutoOk", 0)}, NeedsReview={byTier.GetValueOrDefault("NeedsReview", 0)}, AutoDead={byTier.GetValueOrDefault("AutoDead", 0)}");
+
+    var sortedResults = results
+        .OrderBy(r => TierSortRank(r.Tier))
+        .ThenBy(r => r.Category, StringComparer.OrdinalIgnoreCase)
+        .ThenBy(r => r.Id, StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    var report = new ProbeReport(
+        SchemaVersion: 1,
+        ProbedAt: DateTimeOffset.UtcNow,
+        CatalogRoot: Path.GetFullPath(catalogDir),
+        Summary: new ProbeSummary(
+            Total: results.Count,
+            AutoOk: byTier.GetValueOrDefault("AutoOk", 0),
+            NeedsReview: byTier.GetValueOrDefault("NeedsReview", 0),
+            AutoDead: byTier.GetValueOrDefault("AutoDead", 0)),
+        Entries: sortedResults);
+
+    var reportJsonPath = Path.Combine(outputDir, "report.json");
+    var jsonOptions = new JsonSerializerOptions
+    {
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+    await File.WriteAllTextAsync(reportJsonPath, JsonSerializer.Serialize(report, jsonOptions));
+
+    var reportMdPath = Path.Combine(outputDir, "report.md");
+    await File.WriteAllTextAsync(reportMdPath, BuildMarkdownReport(report));
+
+    Console.WriteLine($"[probe] report.json: {reportJsonPath}");
+    Console.WriteLine($"[probe] report.md  : {reportMdPath}");
+    Console.WriteLine($"[probe] screenshots: {Path.GetFullPath(screenshotsDir)}");
+    return 0;
+}
+
+static int TierSortRank(string tier) => tier switch
+{
+    "AutoDead" => 0,
+    "NeedsReview" => 1,
+    "AutoOk" => 2,
+    _ => 3,
+};
+
+static string BuildMarkdownReport(ProbeReport report)
+{
+    var sb = new StringBuilder();
+    sb.AppendLine("# 식탁보 카탈로그 사이트 헬스 리포트");
+    sb.AppendLine();
+    sb.AppendLine($"- 생성: {report.ProbedAt:yyyy-MM-ddTHH:mm:ssZ}");
+    sb.AppendLine($"- 카탈로그: `{report.CatalogRoot}`");
+    sb.AppendLine($"- 합계: 전체 **{report.Summary.Total}** / AutoOk **{report.Summary.AutoOk}** / NeedsReview **{report.Summary.NeedsReview}** / AutoDead **{report.Summary.AutoDead}**");
+    sb.AppendLine();
+
+    void EmitTier(string tier, string heading)
+    {
+        var entries = report.Entries.Where(e => e.Tier == tier).ToList();
+        sb.AppendLine($"## {heading} ({entries.Count})");
+        sb.AppendLine();
+        if (entries.Count == 0)
+        {
+            sb.AppendLine("_없음_");
+            sb.AppendLine();
+            return;
+        }
+        foreach (var grouping in entries.GroupBy(e => e.Category).OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            sb.AppendLine($"### {grouping.Key} ({grouping.Count()})");
+            sb.AppendLine();
+            foreach (var e in grouping.OrderBy(x => x.Id, StringComparer.OrdinalIgnoreCase))
+            {
+                var status = e.Error is not null ? $"ERR `{e.Error}`" : $"HTTP `{e.HttpStatus}`";
+                sb.AppendLine($"- **{e.Id}** — {e.DisplayName}");
+                sb.AppendLine($"  - 원래: `{e.Url}`");
+                if (!string.Equals(e.Url, e.FinalUrl, StringComparison.Ordinal))
+                    sb.AppendLine($"  - 최종: `{e.FinalUrl}`");
+                sb.AppendLine($"  - 상태: {status}");
+                if (!string.IsNullOrWhiteSpace(e.Title))
+                    sb.AppendLine($"  - 타이틀: {e.Title}");
+                if (e.Signals.Length > 0)
+                    sb.AppendLine($"  - 시그널: `{string.Join("`, `", e.Signals)}`");
+                if (e.ScreenshotPath is not null)
+                    sb.AppendLine($"  - 스크린샷: ![{e.Id}]({e.ScreenshotPath})");
+                sb.AppendLine();
+            }
+        }
+    }
+
+    EmitTier("AutoDead", "사망 추정 (AutoDead)");
+    EmitTier("NeedsReview", "검토 필요 (NeedsReview)");
+    EmitTier("AutoOk", "자동 OK (AutoOk)");
+
+    return sb.ToString();
+}
+
+static async Task<ProbeResult> ProbeWithRetryAsync(IBrowser browser, CatalogEntry entry, int timeoutMs, string screenshotsDir)
+{
+    var first = await ProbeOneAsync(browser, entry, timeoutMs, screenshotsDir);
+    if (first.Error is "timeout" or "connection-reset" or "connection-refused" or "connection-timeout" or "aborted")
+    {
+        await Task.Delay(TimeSpan.FromSeconds(2));
+        return await ProbeOneAsync(browser, entry, timeoutMs, screenshotsDir);
+    }
+    return first;
+}
+
+static async Task<ProbeResult> ProbeOneAsync(IBrowser browser, CatalogEntry entry, int timeoutMs, string screenshotsDir)
+{
+    var probedAt = DateTimeOffset.UtcNow;
+    var finalUrl = entry.Url;
+    int? status = null;
+    string? title = null;
+    string? error = null;
+    string? screenshotRel = null;
+
+    IBrowserContext? context = null;
+    IPage? page = null;
+    try
+    {
+        context = await browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0",
+            ViewportSize = new ViewportSize { Width = 1280, Height = 800 },
+            IgnoreHTTPSErrors = true,
+            Locale = "ko-KR",
+            TimezoneId = "Asia/Seoul",
+            ExtraHTTPHeaders = new Dictionary<string, string>
+            {
+                ["sec-ch-ua"] = "\"Microsoft Edge\";v=\"131\", \"Chromium\";v=\"131\", \"Not_A Brand\";v=\"24\"",
+                ["sec-ch-ua-mobile"] = "?0",
+                ["sec-ch-ua-platform"] = "\"Windows\"",
+                ["sec-ch-ua-platform-version"] = "\"15.0.0\"",
+                ["sec-ch-ua-arch"] = "\"x86\"",
+                ["sec-ch-ua-bitness"] = "\"64\"",
+            },
+        });
+        await context.AddInitScriptAsync(@"
+            Object.defineProperty(navigator, 'platform', { get: () => 'Win32', configurable: true });
+            const fakeUAData = {
+                brands: [
+                    { brand: 'Microsoft Edge', version: '131' },
+                    { brand: 'Chromium', version: '131' },
+                    { brand: 'Not_A Brand', version: '24' }
+                ],
+                mobile: false,
+                platform: 'Windows',
+                getHighEntropyValues: (hints) => Promise.resolve({
+                    architecture: 'x86',
+                    bitness: '64',
+                    model: '',
+                    platform: 'Windows',
+                    platformVersion: '15.0.0',
+                    uaFullVersion: '131.0.0.0',
+                    fullVersionList: [
+                        { brand: 'Microsoft Edge', version: '131.0.0.0' },
+                        { brand: 'Chromium', version: '131.0.0.0' },
+                        { brand: 'Not_A Brand', version: '24.0.0.0' }
+                    ],
+                    wow64: false
+                }),
+                toJSON: function () { return { brands: this.brands, mobile: this.mobile, platform: this.platform }; }
+            };
+            Object.defineProperty(navigator, 'userAgentData', { get: () => fakeUAData, configurable: true });
+        ");
+        page = await context.NewPageAsync();
+
+        var response = await page.GotoAsync(entry.Url, new PageGotoOptions
+        {
+            Timeout = timeoutMs,
+            WaitUntil = WaitUntilState.Load,
+        });
+
+        if (response is not null)
+            status = response.Status;
+        finalUrl = page.Url;
+        try { title = await page.TitleAsync(); } catch { }
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            try { await page.WaitForTimeoutAsync(1500); } catch { }
+            try { title = await page.TitleAsync(); } catch { }
+            try { finalUrl = page.Url; } catch { }
+        }
+
+        var safeId = SanitizeId(entry.Id);
+        var screenshotPath = Path.Combine(screenshotsDir, $"{safeId}.png");
+        await page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = false });
+        screenshotRel = $"screenshots/{safeId}.png";
+    }
+    catch (TimeoutException)
+    {
+        error = "timeout";
+    }
+    catch (PlaywrightException ex)
+    {
+        error = ClassifyPlaywrightError(ex.Message);
+    }
+    catch (Exception ex)
+    {
+        error = $"unknown: {ex.GetType().Name}";
+    }
+    finally
+    {
+        if (page is not null) try { await page.CloseAsync(); } catch { }
+        if (context is not null) try { await context.CloseAsync(); } catch { }
+    }
+
+    return new ProbeResult(
+        Id: entry.Id,
+        DisplayName: entry.DisplayName,
+        Category: entry.Category,
+        Source: entry.Source,
+        Url: entry.Url,
+        FinalUrl: finalUrl,
+        HttpStatus: status,
+        Title: title,
+        Error: error,
+        ScreenshotPath: screenshotRel,
+        Tier: "Unclassified",
+        Signals: Array.Empty<string>(),
+        ProbedAt: probedAt);
+}
+
+static string ClassifyPlaywrightError(string message)
+{
+    if (message.Contains("ERR_NAME_NOT_RESOLVED")) return "dns";
+    if (message.Contains("ERR_CONNECTION_REFUSED")) return "connection-refused";
+    if (message.Contains("ERR_CONNECTION_RESET")) return "connection-reset";
+    if (message.Contains("ERR_CONNECTION_TIMED_OUT")) return "connection-timeout";
+    if (message.Contains("ERR_CERT") || message.Contains("SSL") || message.Contains("TLS")) return "ssl-error";
+    if (message.Contains("ERR_ABORTED")) return "aborted";
+    if (message.Contains("Timeout") || message.Contains("timeout")) return "timeout";
+    if (message.Contains("ERR_TOO_MANY_REDIRECTS")) return "too-many-redirects";
+    return "playwright-error";
+}
+
+static string SanitizeId(string id) =>
+    string.Concat(id.Select(c => char.IsLetterOrDigit(c) || c == '_' || c == '-' ? c : '_'));
+
+static (string tier, string[] signals) Classify(ProbeResult r)
+{
+    if (r.Error is not null)
+    {
+        if (r.Error is "dns" or "connection-refused")
+            return ("AutoDead", [$"error:{r.Error}"]);
+        return ("NeedsReview", [$"error:{r.Error}"]);
+    }
+
+    var strong = new List<string>();
+    var weak = new List<string>();
+
+    if (r.HttpStatus is null)
+        strong.Add("no-http-response");
+    else if (r.HttpStatus >= 400)
+        strong.Add($"http-{r.HttpStatus}");
+
+    if (Uri.TryCreate(r.Url, UriKind.Absolute, out var origUri) &&
+        Uri.TryCreate(r.FinalUrl, UriKind.Absolute, out var finalUri))
+    {
+        var origDomain = RegistrableDomain(origUri.Host);
+        var finalDomain = RegistrableDomain(finalUri.Host);
+        if (!string.Equals(origDomain, finalDomain, StringComparison.OrdinalIgnoreCase))
+            strong.Add($"off-domain-redirect:{finalDomain}");
+    }
+
+    var title = r.Title ?? "";
+    string[] closureKeywords = [
+        "서비스 종료", "서비스가 종료", "운영이 종료", "종료되었습니다",
+        "통합되었습니다", "통합 운영", "이전되었습니다", "변경되었습니다",
+        "페이지를 찾을 수 없", "Page Not Found", "Not Found",
+    ];
+    foreach (var kw in closureKeywords)
+        if (title.Contains(kw, StringComparison.OrdinalIgnoreCase))
+            strong.Add($"closure-keyword:{kw}");
+
+    if (string.IsNullOrWhiteSpace(r.Title))
+        weak.Add("empty-title");
+
+    var all = strong.Concat(weak).ToArray();
+    return strong.Count > 0
+        ? ("NeedsReview", all)
+        : ("AutoOk", all);
+}
+
+static string RegistrableDomain(string host)
+{
+    if (string.IsNullOrEmpty(host)) return host;
+    var parts = host.ToLowerInvariant().Split('.');
+    if (parts.Length <= 2) return string.Join('.', parts);
+    var last = parts[^1];
+    var second = parts[^2];
+    var krSecondLevel = last == "kr" && second is "co" or "go" or "or" or "ac" or "re" or "ne" or "pe" or "mil" or "es" or "hs" or "ms" or "sc" or "kg" or "seoul" or "busan" or "daegu" or "incheon" or "gwangju" or "daejeon" or "ulsan" or "gyeonggi" or "gangwon" or "chungbuk" or "chungnam" or "jeonbuk" or "jeonnam" or "gyeongbuk" or "gyeongnam" or "jeju";
+    return krSecondLevel
+        ? string.Join('.', parts.TakeLast(3))
+        : string.Join('.', parts.TakeLast(2));
+}
+
+static void WriteTierBadge(string tier)
+{
+    var (text, color) = tier switch
+    {
+        "AutoOk" => ("OK", ConsoleColor.Green),
+        "NeedsReview" => ("??", ConsoleColor.Yellow),
+        "AutoDead" => ("XX", ConsoleColor.Red),
+        _ => ("--", ConsoleColor.Gray),
+    };
+    Console.ForegroundColor = color;
+    Console.Write(text);
+    Console.ResetColor();
+}
+
+static async Task<int> RunTriageAsync(string[] args)
+{
+    if (args.Length < 1)
+    {
+        Console.Error.WriteLine("triage: <report-dir> is required");
+        return 2;
+    }
+
+    var reportDir = args[0];
+    var walkAll = args.Contains("--all", StringComparer.OrdinalIgnoreCase);
+    var noBrowser = args.Contains("--no-browser", StringComparer.OrdinalIgnoreCase);
+
+    if (!Directory.Exists(reportDir))
+    {
+        Console.Error.WriteLine($"triage: report directory not found: {reportDir}");
+        return 2;
+    }
+
+    var reportPath = Path.Combine(reportDir, "report.json");
+    if (!File.Exists(reportPath))
+    {
+        Console.Error.WriteLine($"triage: report.json not found in {reportDir}");
+        return 2;
+    }
+
+    var jsonOptions = new JsonSerializerOptions
+    {
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    var report = JsonSerializer.Deserialize<ProbeReport>(await File.ReadAllTextAsync(reportPath), jsonOptions)!;
+    var triagePath = Path.Combine(reportDir, "triage.json");
+
+    TriageState state;
+    if (File.Exists(triagePath))
+    {
+        state = JsonSerializer.Deserialize<TriageState>(await File.ReadAllTextAsync(triagePath), jsonOptions)!;
+        var existingIds = new HashSet<string>(state.Entries.Select(e => e.Probe.Id));
+        foreach (var probe in report.Entries)
+            if (!existingIds.Contains(probe.Id))
+                state.Entries.Add(new TriageEntry(probe, null));
+        Console.WriteLine($"[triage] resuming — existing verdicts: {state.Entries.Count(e => e.Verdict is not null)}");
+    }
+    else
+    {
+        state = new TriageState(
+            SchemaVersion: 1,
+            CatalogRoot: report.CatalogRoot,
+            ProbedAt: report.ProbedAt,
+            UpdatedAt: DateTimeOffset.UtcNow,
+            Entries: report.Entries.Select(e => new TriageEntry(e, null)).ToList());
+    }
+
+    var queue = state.Entries
+        .Where(e => e.Verdict is null)
+        .Where(e => walkAll || e.Probe.Tier == "NeedsReview")
+        .ToList();
+
+    Console.WriteLine($"[triage] report dir : {Path.GetFullPath(reportDir)}");
+    Console.WriteLine($"[triage] mode       : {(walkAll ? "all entries" : "NeedsReview only")}");
+    Console.WriteLine($"[triage] queue      : {queue.Count} entries to review");
+    Console.WriteLine();
+
+    if (queue.Count == 0)
+    {
+        Console.WriteLine("[triage] nothing to do — exiting");
+        return 0;
+    }
+
+    Console.WriteLine("Verdict keys: [o]k / [d]ead / [c]hanged-url / [m]erged-or-renamed / [u]nsure / [s]kip / [q]uit");
+    Console.WriteLine("After verdict, you can add a free-form note. Empty input on the prompt skips the entry.");
+    Console.WriteLine();
+
+    var quit = false;
+    for (var i = 0; i < queue.Count && !quit; i++)
+    {
+        var entry = queue[i];
+        var p = entry.Probe;
+
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine($"=== [{i + 1}/{queue.Count}] {p.Id} — {p.DisplayName} ===");
+        Console.ResetColor();
+        Console.WriteLine($"  카테고리   : {p.Category} ({p.Source})");
+        Console.Write("  Tier      : ");
+        WriteTierBadge(p.Tier);
+        Console.WriteLine($"  ({p.Tier})");
+        if (p.Signals.Length > 0)
+            Console.WriteLine($"  Signals   : {string.Join(", ", p.Signals)}");
+        Console.WriteLine($"  원래 URL  : {p.Url}");
+        if (!string.Equals(p.Url, p.FinalUrl, StringComparison.Ordinal))
+            Console.WriteLine($"  최종 URL  : {p.FinalUrl}");
+        if (p.Error is not null)
+            Console.WriteLine($"  Error     : {p.Error}");
+        else
+            Console.WriteLine($"  Status    : HTTP {p.HttpStatus}");
+        if (!string.IsNullOrWhiteSpace(p.Title))
+            Console.WriteLine($"  Title     : {p.Title}");
+        if (p.ScreenshotPath is not null)
+            Console.WriteLine($"  Screenshot: {Path.Combine(reportDir, p.ScreenshotPath)}");
+        Console.WriteLine();
+
+        if (!noBrowser)
+        {
+            Console.WriteLine("  Live URL을 시스템 브라우저로 엽니다 (직접 클릭해서 확인하세요)...");
+            OpenInSystemBrowser(p.Url);
+        }
+        else
+        {
+            Console.WriteLine($"  Live URL: {p.Url}  (--no-browser, 직접 열어서 확인하세요)");
+        }
+        Console.WriteLine();
+
+        Console.Write("  Verdict [o/d/c/m/u/s/q]: ");
+        var input = (Console.ReadLine() ?? "").Trim();
+        if (string.IsNullOrEmpty(input))
+        {
+            Console.WriteLine("  (skipped — no input)");
+            Console.WriteLine();
+            continue;
+        }
+
+        var key = char.ToLowerInvariant(input[0]);
+        if (key == 'q') { quit = true; break; }
+        if (key == 's')
+        {
+            Console.WriteLine("  (skipped)");
+            Console.WriteLine();
+            continue;
+        }
+
+        string? kind = key switch
+        {
+            'o' => "healthy",
+            'd' => "dead",
+            'c' => "url-changed",
+            'm' => "merged-or-renamed",
+            'u' => "unsure",
+            _ => null,
+        };
+
+        if (kind is null)
+        {
+            Console.WriteLine($"  (unknown key '{key}' — skipped)");
+            Console.WriteLine();
+            continue;
+        }
+
+        string? newUrl = null;
+        if (kind == "url-changed")
+        {
+            Console.Write("  새 URL: ");
+            newUrl = Console.ReadLine()?.Trim();
+            if (string.IsNullOrEmpty(newUrl))
+            {
+                Console.WriteLine("  (URL 없음 — verdict 취소, skipped)");
+                Console.WriteLine();
+                continue;
+            }
+        }
+
+        string? successorId = null;
+        if (kind == "merged-or-renamed")
+        {
+            Console.Write("  후속 기관 Id (선택, 엔터로 건너뛰기): ");
+            successorId = Console.ReadLine()?.Trim();
+            if (string.IsNullOrEmpty(successorId)) successorId = null;
+        }
+
+        Console.Write("  메모 (선택, 엔터로 건너뛰기): ");
+        var notes = Console.ReadLine()?.Trim();
+        if (string.IsNullOrEmpty(notes)) notes = null;
+
+        var verdict = new TriageVerdict(
+            Kind: kind,
+            NewUrl: newUrl,
+            SuccessorId: successorId,
+            Notes: notes,
+            VerdictAt: DateTimeOffset.UtcNow);
+
+        var idx = state.Entries.FindIndex(e => e.Probe.Id == p.Id);
+        state.Entries[idx] = entry with { Verdict = verdict };
+        state = state with { UpdatedAt = DateTimeOffset.UtcNow };
+
+        await File.WriteAllTextAsync(triagePath, JsonSerializer.Serialize(state, jsonOptions));
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine($"  ✔ saved ({kind})");
+        Console.ResetColor();
+        Console.WriteLine();
+    }
+
+    var verdicted = state.Entries.Count(e => e.Verdict is not null);
+    var pending = state.Entries.Count(e => e.Verdict is null);
+    Console.WriteLine($"[triage] complete — verdicts: {verdicted}, pending: {pending}");
+    Console.WriteLine($"[triage] file: {triagePath}");
+    return 0;
+}
+
+static async Task<int> RunIssueAsync(string[] args)
+{
+    if (args.Length < 1)
+    {
+        Console.Error.WriteLine("issue: <report-dir> is required");
+        return 2;
+    }
+
+    var reportDir = args[0];
+    var dryRun = args.Contains("--dry-run", StringComparer.OrdinalIgnoreCase);
+    var repo = ParseOption(args, "--repo");
+    var label = ParseOption(args, "--label");
+
+    if (!Directory.Exists(reportDir))
+    {
+        Console.Error.WriteLine($"issue: report directory not found: {reportDir}");
+        return 2;
+    }
+
+    var triagePath = Path.Combine(reportDir, "triage.json");
+    if (!File.Exists(triagePath))
+    {
+        Console.Error.WriteLine($"issue: triage.json not found in {reportDir} — run 'triage' first");
+        return 2;
+    }
+
+    if (!dryRun)
+    {
+        var auth = await RunProcessAsync("gh", ["auth", "status"]);
+        if (auth.ExitCode != 0)
+        {
+            Console.Error.WriteLine("issue: gh CLI is not authenticated. Run 'gh auth login' first.");
+            Console.Error.WriteLine(auth.Stderr);
+            return 2;
+        }
+    }
+
+    var jsonOptions = new JsonSerializerOptions
+    {
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    var state = JsonSerializer.Deserialize<TriageState>(await File.ReadAllTextAsync(triagePath), jsonOptions)!;
+
+    var qualifying = state.Entries.Where(ShouldFileIssue).ToList();
+    var alreadyFiled = qualifying.Where(e => !string.IsNullOrEmpty(e.Verdict?.IssueUrl)).ToList();
+    var pending = qualifying.Where(e => string.IsNullOrEmpty(e.Verdict?.IssueUrl)).ToList();
+
+    Console.WriteLine($"[issue] report dir       : {Path.GetFullPath(reportDir)}");
+    Console.WriteLine($"[issue] qualifying       : {qualifying.Count}");
+    Console.WriteLine($"[issue] already filed    : {alreadyFiled.Count}");
+    Console.WriteLine($"[issue] to file          : {pending.Count}");
+    if (dryRun)
+        Console.WriteLine($"[issue] mode             : dry-run (no issues will be created)");
+    if (!string.IsNullOrEmpty(repo))
+        Console.WriteLine($"[issue] target repo      : {repo}");
+    if (!string.IsNullOrEmpty(label))
+        Console.WriteLine($"[issue] label            : {label}");
+    Console.WriteLine();
+
+    if (pending.Count == 0)
+    {
+        Console.WriteLine("[issue] nothing to file — exiting");
+        return 0;
+    }
+
+    foreach (var entry in pending)
+    {
+        var p = entry.Probe;
+        var title = BuildIssueTitle(entry);
+        var body = BuildIssueBody(entry, reportDir);
+
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine($"=== {p.Id} ===");
+        Console.ResetColor();
+        Console.WriteLine($"  Title : {title}");
+
+        if (dryRun)
+        {
+            Console.WriteLine($"  Body  :");
+            foreach (var line in body.Split('\n'))
+                Console.WriteLine($"    {line.TrimEnd('\r')}");
+            Console.WriteLine();
+            continue;
+        }
+
+        var ghArgs = new List<string> { "issue", "create", "--title", title, "--body-file", "-" };
+        if (!string.IsNullOrEmpty(repo)) { ghArgs.Add("--repo"); ghArgs.Add(repo); }
+        if (!string.IsNullOrEmpty(label)) { ghArgs.Add("--label"); ghArgs.Add(label); }
+
+        var result = await RunProcessAsync("gh", ghArgs.ToArray(), stdin: body);
+        if (result.ExitCode != 0)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"  ✗ failed (exit {result.ExitCode})");
+            Console.ResetColor();
+            if (!string.IsNullOrWhiteSpace(result.Stderr)) Console.Error.WriteLine($"    {result.Stderr.Trim()}");
+            continue;
+        }
+        var url = result.Stdout.Trim();
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine($"  ✔ {url}");
+        Console.ResetColor();
+
+        var idx = state.Entries.FindIndex(e => e.Probe.Id == p.Id);
+        var newVerdict = entry.Verdict! with { IssueUrl = url };
+        state.Entries[idx] = entry with { Verdict = newVerdict };
+        state = state with { UpdatedAt = DateTimeOffset.UtcNow };
+        await File.WriteAllTextAsync(triagePath, JsonSerializer.Serialize(state, jsonOptions));
+    }
+
+    Console.WriteLine();
+    Console.WriteLine($"[issue] complete");
+    return 0;
+}
+
+static bool ShouldFileIssue(TriageEntry e)
+{
+    if (e.Verdict is null) return false;
+    return e.Verdict.Kind switch
+    {
+        "dead" or "merged-or-renamed" or "unsure" => true,
+        "url-changed" => IsCrossDomainChange(e),
+        _ => false,
+    };
+}
+
+static bool IsCrossDomainChange(TriageEntry e)
+{
+    var v = e.Verdict;
+    if (v is null || string.IsNullOrEmpty(v.NewUrl)) return false;
+    if (!Uri.TryCreate(e.Probe.Url, UriKind.Absolute, out var orig)) return false;
+    if (!Uri.TryCreate(v.NewUrl, UriKind.Absolute, out var nw)) return false;
+    return !string.Equals(RegistrableDomain(orig.Host), RegistrableDomain(nw.Host), StringComparison.OrdinalIgnoreCase);
+}
+
+static string BuildIssueTitle(TriageEntry e)
+{
+    var label = e.Verdict!.Kind switch
+    {
+        "dead" => "사이트 폐쇄 의심",
+        "merged-or-renamed" => "기관 통폐합/명칭변경 의심",
+        "url-changed" => "URL 변경 (도메인 변경)",
+        "unsure" => "추가 조사 필요",
+        _ => e.Verdict.Kind,
+    };
+    return $"[사이트 헬스] {e.Probe.Id} — {label}";
+}
+
+static string BuildIssueBody(TriageEntry e, string reportDir)
+{
+    var sb = new StringBuilder();
+    var p = e.Probe;
+    var v = e.Verdict!;
+
+    sb.AppendLine("## 카탈로그 항목");
+    sb.AppendLine();
+    sb.AppendLine($"- **Id**: `{p.Id}`");
+    sb.AppendLine($"- **DisplayName**: {p.DisplayName}");
+    sb.AppendLine($"- **Category**: {p.Category}");
+    sb.AppendLine($"- **Source**: `{p.Source}`");
+    sb.AppendLine($"- **원래 URL**: {p.Url}");
+    if (!string.Equals(p.Url, p.FinalUrl, StringComparison.Ordinal))
+        sb.AppendLine($"- **최종 URL**: {p.FinalUrl}");
+    if (p.Error is not null)
+        sb.AppendLine($"- **Error**: `{p.Error}`");
+    else
+        sb.AppendLine($"- **HTTP Status**: `{p.HttpStatus}`");
+    if (!string.IsNullOrWhiteSpace(p.Title))
+        sb.AppendLine($"- **Title**: {p.Title}");
+    sb.AppendLine($"- **Tier**: `{p.Tier}`");
+    if (p.Signals.Length > 0)
+        sb.AppendLine($"- **Signals**: `{string.Join("`, `", p.Signals)}`");
+    sb.AppendLine();
+
+    sb.AppendLine("## 사람 판정");
+    sb.AppendLine();
+    sb.AppendLine($"- **Verdict**: `{v.Kind}`");
+    if (!string.IsNullOrEmpty(v.NewUrl))
+        sb.AppendLine($"- **NewUrl**: {v.NewUrl}");
+    if (!string.IsNullOrEmpty(v.SuccessorId))
+        sb.AppendLine($"- **SuccessorId**: `{v.SuccessorId}`");
+    if (!string.IsNullOrEmpty(v.Notes))
+        sb.AppendLine($"- **Notes**: {v.Notes}");
+    sb.AppendLine($"- **VerdictAt**: `{v.VerdictAt:yyyy-MM-ddTHH:mm:ssZ}`");
+    sb.AppendLine();
+
+    sb.AppendLine("## 권장 조치");
+    sb.AppendLine();
+    sb.AppendLine(v.Kind switch
+    {
+        "dead" => "이 항목은 카탈로그에서 삭제할 후보입니다. 추가 검증 후 PR 제출.",
+        "merged-or-renamed" => "후속 기관 정보를 조사한 뒤 (1) URL 교체 (2) 항목 삭제·재등록 (3) 메타데이터(DisplayName/Id) 갱신 중 적절한 방향으로 PR 제출.",
+        "url-changed" => "`Url` 속성을 새 URL로 갱신하는 PR을 제출. 도메인이 변경되었으니 같은 기관이 운영하는 사이트가 맞는지 한 번 더 확인.",
+        "unsure" => "추가 조사 후 verdict를 갱신하거나 수동으로 처리.",
+        _ => "—",
+    });
+    sb.AppendLine();
+
+    sb.AppendLine("## 출처");
+    sb.AppendLine();
+    sb.AppendLine($"- ProbedAt: `{p.ProbedAt:yyyy-MM-ddTHH:mm:ssZ}`");
+    sb.AppendLine($"- triage.json: `{Path.Combine(reportDir, "triage.json")}`");
+    if (p.ScreenshotPath is not null)
+        sb.AppendLine($"- Screenshot: `{Path.Combine(reportDir, p.ScreenshotPath)}`");
+    sb.AppendLine();
+    sb.AppendLine("---");
+    sb.AppendLine("*generated by `src/checksites.cs issue`*");
+
+    return sb.ToString();
+}
+
+static async Task<ProcessResult> RunProcessAsync(string fileName, string[] args, string? stdin = null)
+{
+    var psi = new System.Diagnostics.ProcessStartInfo(fileName)
+    {
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        RedirectStandardInput = stdin is not null,
+        UseShellExecute = false,
+    };
+    foreach (var arg in args) psi.ArgumentList.Add(arg);
+
+    using var proc = System.Diagnostics.Process.Start(psi)!;
+    var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+    var stderrTask = proc.StandardError.ReadToEndAsync();
+    if (stdin is not null)
+    {
+        await proc.StandardInput.WriteAsync(stdin);
+        proc.StandardInput.Close();
+    }
+    await proc.WaitForExitAsync();
+    return new ProcessResult(proc.ExitCode, await stdoutTask, await stderrTask);
+}
+
+static void OpenInSystemBrowser(string url)
+{
+    try
+    {
+        if (OperatingSystem.IsMacOS())
+            System.Diagnostics.Process.Start("open", url);
+        else if (OperatingSystem.IsLinux())
+            System.Diagnostics.Process.Start("xdg-open", url);
+        else if (OperatingSystem.IsWindows())
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo { FileName = url, UseShellExecute = true });
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"  (failed to open browser: {ex.Message})");
+    }
+}
+
+static async Task<int> EnsurePlaywrightAsync()
+{
+    Console.WriteLine("[playwright] ensuring Microsoft Edge (stable) is installed (one-time per machine)...");
+    var exitCode = await Task.Run(() => Microsoft.Playwright.Program.Main(["install", "msedge"]));
+    if (exitCode != 0)
+        Console.Error.WriteLine($"[playwright] install failed with exit code {exitCode}");
+    return exitCode;
+}
+
+static string? ParseOption(string[] args, string name)
+{
+    for (var i = 0; i < args.Length - 1; i++)
+        if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase))
+            return args[i + 1];
+    return null;
+}
+
+static List<CatalogEntry> LoadCatalog(string catalogDir, string[]? onlyIds)
+{
+    var entries = new List<CatalogEntry>();
+    var catalogPath = Path.Combine(catalogDir, "Catalog.xml");
+    var sitesPath = Path.Combine(catalogDir, "sites.xml");
+
+    if (File.Exists(catalogPath))
+    {
+        var doc = XDocument.Load(catalogPath);
+        foreach (var s in doc.Descendants("Service"))
+        {
+            var id = (string?)s.Attribute("Id");
+            var url = (string?)s.Attribute("Url");
+            var name = (string?)s.Attribute("DisplayName") ?? id ?? "";
+            var category = (string?)s.Attribute("Category") ?? "";
+            if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(url))
+            {
+                Console.Error.WriteLine($"[catalog] skipped Service with missing Id/Url: Id='{id}' Url='{url}'");
+                continue;
+            }
+            entries.Add(new CatalogEntry(id!.Trim(), name.Trim(), category.Trim(), url!.Trim(), "Catalog.xml"));
+        }
+    }
+    else
+    {
+        Console.Error.WriteLine($"[catalog] Catalog.xml not found at {catalogPath}");
+    }
+
+    if (File.Exists(sitesPath))
+    {
+        var doc = XDocument.Load(sitesPath);
+        foreach (var s in doc.Descendants("site"))
+        {
+            var host = ((string?)s.Attribute("url"))?.Trim();
+            if (string.IsNullOrWhiteSpace(host)) continue;
+            var id = "IEMode_" + host.Replace('.', '_').Replace('/', '_').Replace(':', '_');
+            var url = host.Contains("://") ? host : $"https://{host}";
+            entries.Add(new CatalogEntry(id, host, "IEMode", url, "sites.xml"));
+        }
+    }
+    else
+    {
+        Console.Error.WriteLine($"[catalog] sites.xml not found at {sitesPath} (skipping)");
+    }
+
+    Console.WriteLine($"[catalog] loaded     : {entries.Count} (Catalog.xml: {entries.Count(e => e.Source == "Catalog.xml")}, sites.xml: {entries.Count(e => e.Source == "sites.xml")})");
+
+    if (onlyIds is { Length: > 0 })
+    {
+        var set = new HashSet<string>(onlyIds, StringComparer.OrdinalIgnoreCase);
+        var filtered = entries.Where(e => set.Contains(e.Id)).ToList();
+        var matched = new HashSet<string>(filtered.Select(e => e.Id), StringComparer.OrdinalIgnoreCase);
+        var missing = onlyIds.Where(id => !matched.Contains(id)).ToList();
+        if (missing.Count > 0)
+            Console.Error.WriteLine($"[catalog] --only ids not found: {string.Join(", ", missing)}");
+        return filtered;
+    }
+
+    return entries;
+}
+
+public sealed record CatalogEntry(
+    string Id,
+    string DisplayName,
+    string Category,
+    string Url,
+    string Source);
+
+public sealed record ProbeResult(
+    string Id,
+    string DisplayName,
+    string Category,
+    string Source,
+    string Url,
+    string FinalUrl,
+    int? HttpStatus,
+    string? Title,
+    string? Error,
+    string? ScreenshotPath,
+    string Tier,
+    string[] Signals,
+    DateTimeOffset ProbedAt);
+
+public sealed record ProbeSummary(int Total, int AutoOk, int NeedsReview, int AutoDead);
+
+public sealed record ProbeReport(
+    int SchemaVersion,
+    DateTimeOffset ProbedAt,
+    string CatalogRoot,
+    ProbeSummary Summary,
+    List<ProbeResult> Entries);
+
+public sealed record TriageVerdict(
+    string Kind,
+    string? NewUrl,
+    string? SuccessorId,
+    string? Notes,
+    DateTimeOffset VerdictAt,
+    string? IssueUrl = null);
+
+public sealed record ProcessResult(int ExitCode, string Stdout, string Stderr);
+
+public sealed record TriageEntry(
+    ProbeResult Probe,
+    TriageVerdict? Verdict);
+
+public sealed record TriageState(
+    int SchemaVersion,
+    string CatalogRoot,
+    DateTimeOffset ProbedAt,
+    DateTimeOffset UpdatedAt,
+    List<TriageEntry> Entries);


### PR DESCRIPTION
## Summary

- 카탈로그(286개 항목)의 접속 가능성을 주기적으로 점검하기 위한 file-based C# 도구 `src/checksites.cs` 추가. Microsoft Edge(Windows x64로 가장)로 헤드리스 probe → strong/weak signal 기반 3-tier 분류 → 사람 판정(triage) → GitHub 이슈 자동 등록(issue) → AI 어시스트로 카탈로그 갱신의 6단계 흐름.
- 자동화는 **검출까지만** 수행하고 "정상 여부"의 최종 판정은 사람이 라이브 브라우저로 직접 확인. triage 단계는 시스템 브라우저로 라이브 URL을 띄워 본인의 쿠키·인증서·확장 그대로 활용.
- `triage.json`을 자기완결적 핸드오프 입력으로 설계해 Claude Code 같은 AI 어시스트가 단일 파일만으로 카탈로그 갱신 PR을 만들 수 있도록 함. 가이드와 진입 프롬프트는 `docs/SITE_HEALTH_WORKFLOW.md`.

## 주요 변경

- `src/checksites.cs` (file-based app, `dotnet run --file`)
  - `probe` — Microsoft.Playwright 1.59 기반, msedge 채널 + UA/Client Hints/`navigator.platform`/`userAgentData`를 모두 Windows Edge로 일치. 병렬 실행(기본 4), transient 에러 단일 재시도, 빈 타이틀 1.5초 후 재조회.
  - `triage` — `NeedsReview` 항목 순회, 시스템 브라우저로 라이브 확인, verdict (`o/d/c/m/u/s/q`) 입력 즉시 `triage.json`에 저장(resume 지원), `--all` / `--no-browser`.
  - `issue` — `gh` CLI로 `dead` / `merged-or-renamed` / `unsure` / cross-domain `url-changed`를 GitHub 이슈로 자동 등록. `IssueUrl`을 verdict에 다시 저장해 멱등성 보장. `--dry-run` / `--repo` / `--label`.
- `docs/SITE_HEALTH_WORKFLOW.md` 신규 — 6단계 흐름, Claude Code 진입 프롬프트(`Closes <IssueUrl>` 패턴 포함), 자동/수동 경계선 매트릭스, triage.json 스키마.
- `README.md` — 카탈로그 품질 관리 도구 섹션에 checksites.cs 항목 추가.
- `.gitignore` — `/health-report/` 추가.

## 검증 결과

50개 비례 샘플 튜닝 실측:

| 라운드 | AutoOk | NeedsReview | False positive | 시간 |
|---|---:|---:|---:|---:|
| 튜닝 전 | 41 | 9 | 5 (`empty-title` only) | 2:07 |
| 튜닝 후 | 46 | 4 | 0 | 2:11 |

남은 4건은 모두 진짜 시그널: HTTP 403 차단 1건, off-domain redirect 1건(기관 통폐합 의심 사례 — `Educar → hanainsure.co.kr`), timeout 2건. 286개 풀 런 추정 시간 ~12분.

## Test plan

- [ ] `dotnet run --file src/checksites.cs -- --help` 동작 확인
- [ ] 소수 샘플 probe (`--only WooriBank,KookminBank`) → `report.json` / `report.md` / 스크린샷 생성 확인
- [ ] 전체 카탈로그 probe 후 NeedsReview/AutoDead 분포 점검
- [ ] triage 실행해서 verdict 저장 + resume 동작 확인 (`--all`, `--no-browser` 포함)
- [ ] `issue --dry-run`으로 본문 미리보기, 그 다음 실제 등록 + `IssueUrl` 멱등성 확인
- [ ] AI 어시스트(`docs/SITE_HEALTH_WORKFLOW.md` 진입 프롬프트) 한 라운드 진행 → 카탈로그 갱신 PR + `Closes <IssueUrl>` 흐름 검증
- [ ] 변경된 항목만 재-probe (`probe --only`)로 stale 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)