### PR TITLE
fix: 중복 Service Id "PayInfo" 통합 (공공기관 항목으로 일원화)

### DIFF
--- a/docs/Catalog.xml
+++ b/docs/Catalog.xml
@@ -1968,6 +1968,7 @@ REG ADD "HKCU\SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist" /v "2"
     <Service Id="PayInfo" DisplayName="계좌정보통합관리서비스" Category="Government" Url="https://www.payinfo.or.kr/">
       <Packages>
         <Package Name="nProtect Online Security" Url="https://supdate.nprotect.net/nprotect/nos_service/windows/install/nos_setup.exe" Arguments="/silent" />
+        <Package Name="MobiSign" Url="https://download.raonsecure.com/MobiSign/v5.0.5.0/xccr.exe" Arguments="/silent" />
       </Packages>
     </Service>
     <Service Id="Enhuf" DisplayName="주택도시기금 기금e든든" Category="Government" Url="https://enhuf.molit.go.kr/">
@@ -2011,12 +2012,6 @@ REG ADD "HKCU\SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist" /v "2"
     <Service Id="ContInsure" DisplayName="나의 숨은 보험금 찾기" Category="Other" Url="https://cont.insure.or.kr/">
       <Packages>
         <Package Name="VertCert" Url="https://cert.niceid.co.kr/vestsignCertWeb/VestCertSetup.exe" Arguments="/silent" />
-      </Packages>
-    </Service>
-    <Service Id="PayInfo" DisplayName="계좌정보통합관리" Category="Other" Url="https://www.payinfo.or.kr">
-      <Packages>
-        <Package Name="nProtect Online Security" Url="https://supdate.nprotect.net/nprotect/nos_service/windows/install/nos_setup.exe" Arguments="/silent" />
-        <Package Name="MobiSign" Url="https://download.raonsecure.com/MobiSign/v5.0.5.0/xccr.exe" Arguments="/silent" />
       </Packages>
     </Service>
     <Service Id="TMoney" DisplayName="티머니카드" Category="Other" Url="https://pay.tmoney.co.kr/" en-US-DisplayName="T-Money">


### PR DESCRIPTION
## 문제
같은 서비스(금융결제원 **계좌정보통합관리서비스**, `payinfo.or.kr`)가 카탈로그의 **공공기관**과 **일반 서비스** 두 섹션에 각각 등록되어 `Service Id="PayInfo"`가 중복됩니다. `Catalog.xsd`는 Service Id의 부모 기준 유일성을 요구합니다.

| | A (공공기관, 유지) | B (일반, 제거) |
|---|---|---|
| DisplayName | 계좌정보통합관리**서비스** | 계좌정보통합관리 |
| Category | **Government** | Other |
| Url | `.../` | `...` |
| Packages | nProtect | nProtect + **MobiSign** |

## 해결
- **공공기관 항목(A)을 정본으로 유지** — 다른 금융결제원 서비스(KFTCVAN, CMSEDI, CMSJiroEdi, BillingOnePlus, Narabill, Trusbill)가 모두 `Government`라 카테고리 일관성 확보.
- **B가 갖고 있던 `MobiSign` 패키지를 A에 병합** — 정보 손실 방지. nProtect·MobiSign 설치 URL 모두 생존(HTTP 200, `.exe`) 확인.
- **일반 섹션의 중복 B 항목 제거.**

## 검증
- XML well-formed ✔
- 중복 `Service Id` 없음 (`sort | uniq -d` 결과 없음) ✔
- 순 변경: +1(MobiSign 추가) / -6(B 블록 제거)

관련: PR #135 리뷰 중 발견된 기존 중복 이슈의 후속 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)