### PR TITLE
feat: 범용 Companion 4종 추가 (7-Zip, 반디집, WebView2 런타임, OpenJDK)

### DIFF
--- a/docs/Catalog.xml
+++ b/docs/Catalog.xml
@@ -11,6 +11,10 @@
     <Companion Id="HancomOfficeViewer" DisplayName="한컴오피스 뷰어" Url="https://www.hancom.com/product/office/officeViewer" Arguments="" en-US-DisplayName="Hancom Office Viewer" />
     <Companion Id="AdobeAcrobatReader" DisplayName="Adobe Acrobat Reader" Url="https://get.adobe.com/kr/reader" Arguments="" en-US-DisplayName="Adobe Acrobat Reader" />
     <Companion Id="RaiDrive " DisplayName="RaiDrive" Url="https://www.raidrive.com/download" Arguments="" en-US-DisplayName="RaiDrive" />
+    <Companion Id="SevenZip" DisplayName="7-Zip (LGPL)" Url="https://www.7-zip.org/download.html" Arguments="" en-US-DisplayName="7-Zip (LGPL)" />
+    <Companion Id="Bandizip" DisplayName="반디집" Url="https://www.bandisoft.com/bandizip/" Arguments="" en-US-DisplayName="Bandizip" />
+    <Companion Id="EdgeWebView2Runtime" DisplayName="Microsoft Edge WebView2 런타임" Url="https://developer.microsoft.com/ko-kr/microsoft-edge/webview2/" Arguments="" en-US-DisplayName="Microsoft Edge WebView2 Runtime" />
+    <Companion Id="EclipseTemurin" DisplayName="OpenJDK (GPLv2+CE)" Url="https://adoptium.net/temurin/releases/" Arguments="" en-US-DisplayName="OpenJDK (GPLv2+CE)" />
   </Companions>
   <InternetServices>
     <!-- 인터넷 뱅킹 시작 -->

--- a/docs/generate.cs
+++ b/docs/generate.cs
@@ -380,6 +380,10 @@ CompanionCollection companions = [
     new("HancomOfficeViewer", "한컴오피스 뷰어", "https://www.hancom.com/product/office/officeViewer", "", "Hancom Office Viewer"),
     new("AdobeAcrobatReader", "Adobe Acrobat Reader", "https://get.adobe.com/kr/reader", "", "Adobe Acrobat Reader"),
     new("RaiDrive", "RaiDrive", "https://www.raidrive.com/download", "", "RaiDrive"),
+    new("SevenZip", "7-Zip (LGPL)", "https://www.7-zip.org/download.html", "", "7-Zip (LGPL)"),
+    new("Bandizip", "반디집", "https://www.bandisoft.com/bandizip/", "", "Bandizip"),
+    new("EdgeWebView2Runtime", "Microsoft Edge WebView2 런타임", "https://developer.microsoft.com/ko-kr/microsoft-edge/webview2/", "", "Microsoft Edge WebView2 Runtime"),
+    new("EclipseTemurin", "OpenJDK (GPLv2+CE)", "https://adoptium.net/temurin/releases/", "", "OpenJDK (GPLv2+CE)"),
 ];
 
 ServiceCollection services = [


### PR DESCRIPTION
## 개요
전자정부/인터넷뱅킹 환경에서 자주 마주치는 **범용 보조 소프트웨어**를 공식 다운로드 페이지 링크(`<Companion>`) 형태로 추가합니다. `docs/generate.cs`(생성 소스)와 `docs/Catalog.xml`(생성 결과물) 양쪽에 반영했습니다.

| Id | DisplayName | 용도 | Url | 라이선스 |
|---|---|---|---|---|
| `SevenZip` | 7-Zip (LGPL) | 일반 압축 해제 | 7-zip.org | LGPL |
| `Bandizip` | 반디집 | `.egg`/`.alz` 등 한국식 압축 포맷 | bandisoft.com | 독점 프리웨어 |
| `EdgeWebView2Runtime` | Microsoft Edge WebView2 런타임 | 최신 보안·인증 클라이언트의 내장 웹뷰 의존성 | MS 공식 | 독점(재배포 허용) |
| `EclipseTemurin` | OpenJDK (GPLv2+CE) | 레거시 Java 기반 서비스 | adoptium.net | GPLv2+CE |

## 검증
- XML well-formed ✔
- Companion Id 중복 없음 ✔
- `generate.cs` ↔ `Catalog.xml` 신규 4개 1:1 정합 ✔
- 4개 다운로드 URL **생존(HTTP 200)** 확인 ✔ (브라우저 UA)

## 설계 근거
- **간접(링크) 형태** 유지: 직접 배포가 아니므로 배포 의무가 발생하지 않아, Apache-2.0 공용 카탈로그를 참조하는 **downstream 상용 소비자에게도 안전**. copyleft 항목(7-Zip=LGPL, OpenJDK=GPLv2+CE)은 DisplayName에 라이선스 표기.
- 편입 기준: "은행/전자정부 업무 완료 과정에서 실제로 요구·마주치는 마찰인가?" → 런타임(WebView2)·압축 해제(7-Zip/반디집)·Java(레거시) 모두 해당.

관련 이슈: #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)