### PR TITLE
feat: 모두의 프린터 분리배포 요구 SW를 Companion으로 추가 (resolve #137)

### DIFF
--- a/docs/Catalog.xml
+++ b/docs/Catalog.xml
@@ -8,6 +8,7 @@
 	-->
   <Companions>
     <Companion Id="EveryonesPrinter" DisplayName="모두의 프린터" Url="https://modu-print.com/모두의-프린터-다운로드" Arguments="" en-US-DisplayName="Everyone's Printer" />
+    <Companion Id="EveryonesPDF" DisplayName="모두의 PDF" Url="https://modu-print.com/모두의pdf-다운로드" Arguments="" en-US-DisplayName="Everyone's PDF" />
     <Companion Id="HancomOfficeViewer" DisplayName="한컴오피스 뷰어" Url="https://www.hancom.com/product/office/officeViewer" Arguments="" en-US-DisplayName="Hancom Office Viewer" />
     <Companion Id="AdobeAcrobatReader" DisplayName="Adobe Acrobat Reader" Url="https://get.adobe.com/kr/reader" Arguments="" en-US-DisplayName="Adobe Acrobat Reader" />
     <Companion Id="RaiDrive " DisplayName="RaiDrive" Url="https://www.raidrive.com/download" Arguments="" en-US-DisplayName="RaiDrive" />
@@ -15,6 +16,9 @@
     <Companion Id="Bandizip" DisplayName="반디집" Url="https://www.bandisoft.com/bandizip/" Arguments="" en-US-DisplayName="Bandizip" />
     <Companion Id="EdgeWebView2Runtime" DisplayName="Microsoft Edge WebView2 런타임" Url="https://developer.microsoft.com/ko-kr/microsoft-edge/webview2/" Arguments="" en-US-DisplayName="Microsoft Edge WebView2 Runtime" />
     <Companion Id="EclipseTemurin" DisplayName="OpenJDK (GPLv2+CE)" Url="https://adoptium.net/temurin/releases/" Arguments="" en-US-DisplayName="OpenJDK (GPLv2+CE)" />
+    <Companion Id="Ghostscript" DisplayName="Ghostscript (AGPL)" Url="https://www.ghostscript.com/releases/gsdnld.html" Arguments="" en-US-DisplayName="Ghostscript (AGPL)" />
+    <Companion Id="GhostPCL" DisplayName="GhostPCL (AGPL)" Url="https://www.ghostscript.com/releases/gpcldnld.html" Arguments="" en-US-DisplayName="GhostPCL (AGPL)" />
+    <Companion Id="VisualCppRedist" DisplayName="Visual C++ 재배포 가능 패키지" Url="https://learn.microsoft.com/ko-kr/cpp/windows/latest-supported-vc-redist" Arguments="" en-US-DisplayName="Visual C++ Redistributable" />
   </Companions>
   <InternetServices>
     <!-- 인터넷 뱅킹 시작 -->

--- a/docs/generate.cs
+++ b/docs/generate.cs
@@ -377,6 +377,7 @@ SiteCollection sites = [
 
 CompanionCollection companions = [
     new("EveryonesPrinter", "모두의 프린터", "https://modu-print.com/모두의-프린터-다운로드", "", "Everyone's Printer"),
+    new("EveryonesPDF", "모두의 PDF", "https://modu-print.com/모두의pdf-다운로드", "", "Everyone's PDF"),
     new("HancomOfficeViewer", "한컴오피스 뷰어", "https://www.hancom.com/product/office/officeViewer", "", "Hancom Office Viewer"),
     new("AdobeAcrobatReader", "Adobe Acrobat Reader", "https://get.adobe.com/kr/reader", "", "Adobe Acrobat Reader"),
     new("RaiDrive", "RaiDrive", "https://www.raidrive.com/download", "", "RaiDrive"),
@@ -384,6 +385,9 @@ CompanionCollection companions = [
     new("Bandizip", "반디집", "https://www.bandisoft.com/bandizip/", "", "Bandizip"),
     new("EdgeWebView2Runtime", "Microsoft Edge WebView2 런타임", "https://developer.microsoft.com/ko-kr/microsoft-edge/webview2/", "", "Microsoft Edge WebView2 Runtime"),
     new("EclipseTemurin", "OpenJDK (GPLv2+CE)", "https://adoptium.net/temurin/releases/", "", "OpenJDK (GPLv2+CE)"),
+    new("Ghostscript", "Ghostscript (AGPL)", "https://www.ghostscript.com/releases/gsdnld.html", "", "Ghostscript (AGPL)"),
+    new("GhostPCL", "GhostPCL (AGPL)", "https://www.ghostscript.com/releases/gpcldnld.html", "", "GhostPCL (AGPL)"),
+    new("VisualCppRedist", "Visual C++ 재배포 가능 패키지", "https://learn.microsoft.com/ko-kr/cpp/windows/latest-supported-vc-redist", "", "Visual C++ Redistributable"),
 ];
 
 ServiceCollection services = [


### PR DESCRIPTION
## 개요
모두의 프린터 설치 시 기본 포함되던 요구 소프트웨어가 라이선스 문제로 분리 배포됨에 따라, **직접 다운로드가 아닌 공식 다운로드 페이지 링크**(`<Companion>`)로 안내하도록 추가합니다. (이슈 #137)

| Id | DisplayName | Url | 라이선스 |
|---|---|---|---|
| `EveryonesPDF` | 모두의 PDF | modu-print.com | 독점 프리웨어 |
| `Ghostscript` | Ghostscript (AGPL) | ghostscript.com/releases/gsdnld.html | AGPL |
| `GhostPCL` | GhostPCL (AGPL) | ghostscript.com/releases/gpcldnld.html | AGPL |
| `VisualCppRedist` | Visual C++ 재배포 가능 패키지 | MS Learn (latest supported) | 독점(재배포 허용) |

## 검증
- XML well-formed ✔
- Companion Id 중복 없음 ✔
- `generate.cs` ↔ `Catalog.xml` 4개 1:1 정합 ✔
- 4개 URL **생존(HTTP 200)** 확인 ✔ (브라우저 UA, 한글 URL은 UTF-8 인코딩 확인)

## 설계 근거
- **간접(링크) 형태** 유지: 특히 **Ghostscript/GhostPCL은 AGPL**이라, 직접 배포(무인설치) 시 배포자에게 소스 제공 등 §6 의무가 발생. 링크로 두면 배포 행위가 없어 Apache-2.0 공용 카탈로그를 참조하는 downstream 상용 소비자에게도 안전. copyleft 항목은 DisplayName에 `(AGPL)` 표기.
- VC++는 특정 구버전 박제가 아닌 MS "latest supported" 페이지로 안내 → EOL 버전 노출/링크 부패 회피.

## 참고
- CLA 미서명으로 머지 불가 상태였던 **draft PR #138의 내용을 대체**합니다. (#138은 이 PR 머지 후 정리 예정)

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)